### PR TITLE
feat: add additional fields from log message to discord fields

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -10,6 +10,15 @@ const embedColors: Record<string, ColorResolvable> = {
 	60: '#e83938', //fatal
 };
 
+// https://discordjs.guide/popular-topics/embeds.html#embed-limits
+const MAX_FIELD_VALUE = 1024,
+	MAX_FIELD_NAME = 256,
+	MAX_FIELDS = 25;
+
+const trim = (str: string, max: number) => {
+	return str.length > max ? `${str.slice(0, max - 3)}...` : str;
+};
+
 async function discordTransport(options: { webhookURL: string }) {
 	if (!options.webhookURL) {
 		throw new Error('The required option: webhookURL is missing.');
@@ -21,19 +30,33 @@ async function discordTransport(options: { webhookURL: string }) {
 
 	return build(async function (source) {
 		for await (const message of source) {
+			const { level, msg, err, time, ...rest } = message;
+
+			const fields = Object.entries(rest).map(([name, value]) => ({
+				name: trim(name, MAX_FIELD_NAME),
+				value: trim(String(value), MAX_FIELD_VALUE),
+			}));
+
+			const fieldsExceedingLimit = fields.length > MAX_FIELDS;
+
 			const embed = new EmbedBuilder()
-				.setColor(embedColors[message.level]!)
-				.setTitle(String(message.msg))
-				.setTimestamp();
+				.setColor(embedColors[level]!)
+				.setTitle(String(msg))
+				.addFields(fieldsExceedingLimit ? fields.slice(0, MAX_FIELDS) : fields)
+				.setTimestamp(typeof time === 'number' ? time : null);
+
+			if (fieldsExceedingLimit) {
+				embed.setFooter({
+					text: `Some fields have been excluded from the log. The maximum allowed is ${MAX_FIELDS} fields.`,
+				});
+			}
 
 			await webhook.send({
 				embeds: [embed],
 			});
 			await webhook.send(
 				'```\n' +
-					(message.err
-						? String(message.err.stack).slice(0, 4000)
-						: 'No stack trace') +
+					(err ? trim(String(err.stack), 4000) : 'No stack trace') +
 					'\n```',
 			);
 		}


### PR DESCRIPTION
Sometimes additional metadata is added inside logger object, for example serviceName in a microservice architecture is really important information in a log. This PR will add these additional fields from log message in discord fields.

![Screenshot 2024-07-22 001950](https://github.com/user-attachments/assets/336c166e-0d1b-4ae7-9653-de4f5ec67dbd)
